### PR TITLE
Clarify OPFS availability

### DIFF
--- a/README-upstream.md
+++ b/README-upstream.md
@@ -28,7 +28,8 @@ There are three ways to use SQLite Wasm:
 - [in the main thread](#in-the-main-thread-without-opfs)
 
 SQLite can be loaded in any thread, but the origin private file system (OPFS) storage
-back-end is only available when it is loaded in a worker thread.
+back-end is only available when it is loaded in a worker thread in a
+[secure context](https://developer.mozilla.org/docs/Web/Security/Secure_Contexts).
 
 ### In a wrapped worker (with OPFS if available):
 

--- a/README-upstream.md
+++ b/README-upstream.md
@@ -27,8 +27,8 @@ There are three ways to use SQLite Wasm:
 - [in a worker](#in-a-worker-with-opfs-if-available)
 - [in the main thread](#in-the-main-thread-without-opfs)
 
-Only the worker versions allow you to use the origin private file system (OPFS)
-storage back-end.
+SQLite can be loaded in any thread, but the origin private file system (OPFS) storage
+back-end is only available when it is loaded in a worker thread.
 
 ### In a wrapped worker (with OPFS if available):
 


### PR DESCRIPTION
The original phrase caused confusion with one of the users of SQLite's own package. The reader saw the phrase in your project.